### PR TITLE
Add 8legs / 80legs regex

### DIFF
--- a/data/applications-bots.php
+++ b/data/applications-bots.php
@@ -4,6 +4,7 @@ namespace WhichBrowser\Data;
 
 Applications::$BOTS = [
     [ 'name' => '80legs',                       'id'    => '008',      'regexp' => '/(?:^|\s)008\/([0-9.]*)/u' ],
+    [ 'name' => '80legs',                       'id'    => '008',      'regexp' => '/80?legs/u' ],
     [ 'name' => '360spider',                    'id'    => '360',      'regexp' => '/360Spider/u' ],
     [ 'name' => '360spider',                    'id'    => '360',      'regexp' => '/360spider-image/u' ],
     [ 'name' => 'A6 Indexer',                   'id'    => 'a6',      'regexp' => '/A6-Indexer(?:\/([0-9.]*))?/u' ],

--- a/tests/data/bots/generic.yaml
+++ b/tests/data/bots/generic.yaml
@@ -1010,3 +1010,7 @@
     headers: 'User-Agent: Cloudflare-SSLDetector'
     readable: 'Cloudflare SSL Detector'
     result: { browser: { name: 'Cloudflare SSL Detector' }, device: { type: bot } }
+-
+    headers: 'User-Agent: 8LEGS'
+    readable: '80legs'
+    result: { browser: { name: 80legs }, device: { type: bot } }


### PR DESCRIPTION
Our test servers were getting hit with the combinations of `8legs` and `80legs`

Doing research on the internet there are many documented cases of `8LEGS`

Link: https://www.google.com/search?q=8legs+user+agent

Link: https://en.wikipedia.org/wiki/80legs