### PR TITLE
Add 8legs / 80legs regex

### DIFF
--- a/src/Analyser/Header/Useragent/Bot.php
+++ b/src/Analyser/Header/Useragent/Bot.php
@@ -31,6 +31,14 @@ trait Bot
             $this->data->device->type = Constants\DeviceType::BOT;
         }
 
+        /* Detect 80legs bots based on url in the UA string */
+
+        if (preg_match('/80?legs/iu', $ua)) {
+            $this->data->browser->name = '80legs';
+
+            $this->data->device->type = Constants\DeviceType::BOT;
+        }
+
         /* Detect based on a predefined list or markers */
 
         if ($bot = Data\Applications::identifyBot($ua)) {

--- a/tests/data/bots/generic.yaml
+++ b/tests/data/bots/generic.yaml
@@ -1010,3 +1010,7 @@
     headers: 'User-Agent: Cloudflare-SSLDetector'
     readable: 'Cloudflare SSL Detector'
     result: { browser: { name: 'Cloudflare SSL Detector' }, device: { type: bot } }
+-
+    headers: 'User-Agent: 8LEGS'
+    readable: '80legs'
+    result: { browser: { name: 80legs }, device: { type: bot } }


### PR DESCRIPTION
Our test servers were getting hit with the combinations of `8legs` and `80legs` 

Doing research on the internet there are many documented cases of `8LEGS`

Link: https://www.google.com/search?q=8legs+user+agent

Link: https://en.wikipedia.org/wiki/80legs
