### PR TITLE
Add Qwantify search engine

### DIFF
--- a/src/Analyser/Header/Useragent/Bot.php
+++ b/src/Analyser/Header/Useragent/Bot.php
@@ -12,6 +12,7 @@ use WhichBrowser\SearchEngines\Google;
 use WhichBrowser\SearchEngines\Bing;
 use WhichBrowser\SearchEngines\Yahoo;
 use WhichBrowser\SearchEngines\Baidu;
+use WhichBrowser\SearchEngines\Qwantify;
 
 trait Bot
 {
@@ -118,6 +119,18 @@ trait Bot
                 $this->data->browser->name = $Baidu->name ?? '';
                 $this->data->browser->version = $Baidu->version ?? '';
                 $this->data->device->type = $Baidu->bot ?? '';
+            }
+
+        // Detect qwantify search engine bots
+        // News bot only uses `qwant` and not `qwantify`
+        } elseif (preg_match('/qwant/iu', $ua, $match)) {
+            $Qwantify = new Qwantify($ua);
+
+            // Only run if the class found a regex match
+            if ($Qwantify->found == true) {
+                $this->data->browser->name = $Qwantify->name ?? '';
+                $this->data->browser->version = $Qwantify->version ?? '';
+                $this->data->device->type = $Qwantify->bot ?? '';
             }
 
         // Detect facebook bots

--- a/src/SearchEngines/Qwantify.php
+++ b/src/SearchEngines/Qwantify.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace WhichBrowser\SearchEngines;
+
+use WhichBrowser\Constants;
+use WhichBrowser\Data;
+use WhichBrowser\Model\Version;
+
+class Qwantify
+{
+    /** @var string */
+    public $name;
+
+    /** @var array */
+    public $version;
+
+    /** @var string */
+    public $bot;
+
+    /** @var string default set to false */
+    public $found = false;
+
+    /**
+     * Detect Qwantify search engine bots
+     *
+     * @internal
+     *
+     * @return array
+     */
+    public function __construct($ua)
+    {
+        /* Detect `fake` and `dead` bots before real bots */
+        if (preg_match('/(MSIE\s(2|3|4|5|6|7|8|9|10)|qwantbot)/iu', $ua, $match)) {
+            $this->name = 'Fake Qwantify Bot';
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwantify News Bot */
+        } elseif (preg_match('/Qwant-news\/([0-9.]*)/u', $ua, $match)) {
+            $this->name = 'Qwantify News Bot';
+            $this->version = new Version([ 'value' => $match[1] ]);
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwantify Bleriot Bot */
+        } elseif (preg_match('/Qwantify\/Bleriot\/([0-9.]*)/u', $ua, $match)) {
+            $this->name = 'Qwantify Bleriot Bot';
+            $this->version = new Version([ 'value' => $match[1] ]);
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwantify Ai4eu Bot */
+        } elseif (preg_match('/Qwantify\/ai4eu\/([0-9.]*)/u', $ua, $match)) {
+            $this->name = 'Qwantify Ai4eu Bot';
+            $this->version = new Version([ 'value' => $match[1] ]);
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwantify Mermoz Bot */
+        } elseif (preg_match('/Qwantify\/Mermoz\/([0-9.]*)/u', $ua, $match)) {
+            $this->name = 'Qwantify Mermoz Bot';
+            $this->version = new Version([ 'value' => $match[1] ]);
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwantify Vr Bot */
+        } elseif (preg_match('/Qwantify\/vR/u', $ua, $match)) {
+            $this->name = 'Qwantify Vr Bot';
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwant Research Bot */
+        } elseif (preg_match('/Qwant Research Bot\/([0-9.]*)/u', $ua, $match)) {
+            $this->name = 'Qwant Research Bot';
+            $this->version = new Version([ 'value' => $match[1] ]);
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwantify Bot 1 (place at end) */
+        } elseif (preg_match('/Qwantify Bot ([0-9.]*)/u', $ua, $match)) {
+            $this->name = 'Qwantify Bot';
+            $this->version = new Version([ 'value' => $match[1] ]);
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+
+        /* Qwantify Bot 2 (place at end) */
+        } elseif (preg_match('/Qwantify\/([0-9.]*)/u', $ua, $match)) {
+            $this->name = 'Qwantify Bot';
+            $this->version = new Version([ 'value' => $match[1] ]);
+            $this->bot = Constants\DeviceType::BOT;
+            $this->found = true;
+        }
+
+        return;
+    }
+}

--- a/tests/data/bots/generic.yaml
+++ b/tests/data/bots/generic.yaml
@@ -1434,3 +1434,39 @@
     headers: 'User-Agent: Mozilla/5.0 (compatible; Baiduspider/2.0;+http://www.baidu.com/search/spider.html'
     readable: 'Fake Baiduspider Bot'
     result: { browser: { name: 'Fake Baiduspider Bot' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Qwantify Bot 1.0'
+    readable: 'Qwantify Bot 1.0'
+    result: { browser: { name: 'Qwantify Bot', version: '1.0' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwantify/2.4w; +https://www.qwant.com/)'
+    readable: 'Qwantify Bot 2.4'
+    result: { browser: { name: 'Qwantify Bot', version: '2.4' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwant-news/2.0; +https://www.qwant.com/)'
+    readable: 'Qwantify News Bot 2.0'
+    result: { browser: { name: 'Qwantify News Bot', version: '2.0' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwantify/Bleriot/1.1; +https://help.qwant.com/bot)'
+    readable: 'Qwantify Bleriot Bot 1.1'
+    result: { browser: { name: 'Qwantify Bleriot Bot', version: '1.1' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwantify/ai4eu/1.1; +https://help.qwant.com/bot;)'
+    readable: 'Qwantify Ai4eu Bot 1.1'
+    result: { browser: { name: 'Qwantify Ai4eu Bot', version: '1.1' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwantify/Mermoz/0.1; +https://www.qwant.com/; +https://www.github.com/QwantResearch/mermoz)'
+    readable: 'Qwantify Mermoz Bot 0.1'
+    result: { browser: { name: 'Qwantify Mermoz Bot', version: '0.1' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwantify/vR; +https://www.qwant.com/)'
+    readable: 'Qwantify Vr Bot'
+    result: { browser: { name: 'Qwantify Vr Bot' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwant Research Bot/1.0; +https://www.qwant.com/)'
+    readable: 'Qwant Research Bot 1.0'
+    result: { browser: { name: 'Qwant Research Bot', version: '1.0' }, device: { type: bot } }
+-
+    headers: 'User-Agent: Mozilla/5.0 (compatible; Qwantbot/1.0; +https://qwantbot.net/)'
+    readable: 'Fake Qwantify Bot'
+    result: { browser: { name: 'Fake Qwantify Bot' }, device: { type: bot } }


### PR DESCRIPTION
### Qwantify Bot (current 1.0)

```
Qwantify Bot 1.0
```

### Qwantify Bot (current 2.4w)

```
Mozilla/5.0 (compatible; Qwantify/2.4w; +https://www.qwant.com/)
Mozilla/5.0 (compatible; Qwantify/2.4w; +https://www.qwant.com/)/2.4w
Mozilla/5.0 (compatible; Qwantify/2.4w; https://www.qwant.com/)/2.4w
```

### Qwantify News Bot

```
Mozilla/5.0 (compatible; Qwant-news/2.0; +https://www.qwant.com/)
```

### Qwantify Bleriot Bot

```
Mozilla/5.0 (compatible; Qwantify/Bleriot/1.1; +https://help.qwant.com/bot)
user-agent Mozilla/5.0 (compatible; Qwantify/Bleriot/1.1; +https://help.qwant.com/bot;)
Mozilla/5.0 (compatible; Qwantify/Bleriot/1.1; +https://help.qwant.com/bot)
Mozilla/5.0 (compatible; Qwantify/Bleriot/1.2.1; +https://help.qwant.com/bot)
```

### Qwantify Ai4eu Bot

```
Mozilla/5.0 (compatible; Qwantify/ai4eu/1.1; +https://help.qwant.com/bot;)
```

### Qwantify Mermoz Bot

```
Mozilla/5.0 (compatible; Qwantify/Mermoz/0.1; +https://www.qwant.com/; +https://www.github.com/QwantResearch/mermoz)
```

### Qwantify Vr Bot

```
Mozilla/5.0 (compatible; Qwantify/vR; +https://www.qwant.com/)
```

### Qwant Research Bot

```
Mozilla/5.0 (compatible; Qwant Research Bot/1.0; +https://www.qwant.com/)
```

### Reverse DNS

```
qwantbot-91-242-162-20.search.qwant.com
```

## Dead Bots (2015 - 2016)

### Qwantify

```
Mozilla/5.0 (compatible; Qwantify/2.3w; +https://www.qwant.com/)/2.3w
Mozilla/5.0 (compatible; Qwantify/2.2w; +https://www.qwant.com/)/*
Mozilla/5.0 (compatible; Qwantify/2.1dw; +https://www.qwant.com/)/*
Mozilla/5.0 (compatible; Qwantify/2.1w; +https://www.qwant.com/)/*
Mozilla/5.0 (compatible; Qwantify/2.1n; +https://www.qwant.com/)/*
Mozilla/5.0 (compatible; Qwantify/2.0n; +https://www.qwant.com/)/*
Mozilla/5.0 (compatible; Qwantify/2.0n; +https://www.qwant.com/)
Mozilla/5.0 (compatible; Qwantify/2.0; +https://www.qwant.com/)
```

Not going to add dead bots to this pr.

Link: https://www.qwant.com/

Link: https://help.qwant.com/bot

Add fake bot to the rules:

```
Mozilla/5.0 (compatible; Qwantbot/1.0; +https://qwantbot.net/)
```

Above: Fake namespace, `qwantbot.net` is fake and the correct one is `qwant.com`

Can detect `/qwantbot/` regex pattern for this fake.
