### PR TITLE
Steam Game Overlay (Gaming) Browser added version number

### DIFF
--- a/data/applications-others.php
+++ b/data/applications-others.php
@@ -140,10 +140,11 @@ Applications::$OTHERS = [
     ],
 
     Constants\BrowserType::APP_GAME => [
-        [ 'name' => 'EA Origin',            'id'    => 'origin',      'regexp' =>'/Origin\/([0-9.]*)/u' ],
-        [ 'name' => 'SecondLife',           'id'    => 'secondlife',      'regexp' =>'/SecondLife\/([0-9.]*)/u' ],
-        [ 'name' => 'Valve Steam',          'id'    => 'valve',      'regexp' =>'/Valve Steam/u' ],
-        [ 'name' => 'Raptr',                'id'    => 'raptr',      'regexp' =>'/Raptr/u' ],
+        [ 'name' => 'EA Origin',            'id'    => 'origin',          'regexp' => '/Origin\/([0-9.]*)/u' ],
+        [ 'name' => 'SecondLife',           'id'    => 'secondlife',      'regexp' => '/SecondLife\/([0-9.]*)/u' ],
+        [ 'name' => 'Valve Steam',          'id'    => 'valve',           'regexp' => '/Valve Steam GameOverlay\/([0-9.]*)/u' ],
+        [ 'name' => 'Valve Steam',          'id'    => 'valve',           'regexp' => '/Valve Steam/u' ],
+        [ 'name' => 'Raptr',                'id'    => 'raptr',           'regexp' => '/Raptr/u' ],
     ],
 
     Constants\BrowserType::APP => [

--- a/tests/data/gaming/other.yaml
+++ b/tests/data/gaming/other.yaml
@@ -10,3 +10,7 @@
     headers: 'User-Agent: Mozilla/5.0 (Linux; U; Android OUYA 4.1.2; en-us; OUYA  Build/JZO54L-OUYA) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30'
     result: { browser: { name: 'Android Browser' }, engine: { name: Webkit, version: '534.30' }, os: { name: Android, version: 4.1.2 }, device: { type: gaming, subtype: console, manufacturer: OUYA, model: OUYA } }
     readable: 'Android Browser on an OUYA running Android 4.1.2'
+-
+    headers: 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 10.0; en-US; Valve Steam GameOverlay/1513371133; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.62 Safari/537.36'
+    result: { browser: { name: 'Valve Steam', family: { name: Chrome, version: 62 }, version: '1513371133', type: 'app:game' }, engine: { name: Blink }, os: { name: Windows, version: { value: '10.0', alias: '10' } }, device: { type: desktop } }
+    readable: 'Valve Steam 1513371133 on Windows 10'


### PR DESCRIPTION
Steam Game Overlay (Gaming) Version Browser

### Before

```
Browser Name: Valve Steam
Browser Version:
```

### After

```
Browser Name: Valve Steam
Browser Version: 1513371133
```


### Before

```
Valve Steam on Windows 10
```

### After

```
Valve Steam 1513371133 on Windows 10
```
